### PR TITLE
feat: added exec_time and exec_memeory for assessment submission

### DIFF
--- a/src/Modules/Dashboard/Dashboard.tsx
+++ b/src/Modules/Dashboard/Dashboard.tsx
@@ -40,6 +40,28 @@ const AssessmentColumnDef: ColumnsType<AssessmentQueryResult[number]> = [
             return null;
         },
     },
+    {
+        title: 'Execution Time (s)',
+        dataIndex: 'execution_time',
+        key: 'execution_time',
+        sorter: (a, b) => a.execution_time - b.execution_time,
+        render: (time) => time || 'NA',
+    },
+    {
+        title: 'Execution Memory (MB)',
+        dataIndex: 'execution_memory',
+        key: 'execution_memory',
+        sorter: (a, b) => a.execution_memory - b.execution_memory,
+        render: (memory: number) => memory / 1024 || 'NA',
+    },
+    {
+        title: 'Joined',
+        dataIndex: 'created_at',
+        key: 'joined',
+        render: (date: string) => dayjs(date).format('h:mm A MMM DD, YYYY'),
+        sorter: (a, b) => dayjs(a.created_at).unix() - dayjs(b.created_at).unix(),
+        defaultSortOrder: 'descend',
+    },
     StatusColDef('status'),
     {
         title: 'Joined',
@@ -120,7 +142,7 @@ const Dashboard = () => {
         <div className="container">
             <Title level={2}>Dashboard</Title>
             <Space size={24} direction="vertical" style={{ width: '100%' }}>
-                 <Row gutter={16}>
+                <Row gutter={16}>
                     <Col span={8}>
                         <Card>
                             <Statistic loading={loading} title="Total Invited" value={assessments.length} />

--- a/src/Modules/common/CodeEditor/CodeEditor.tsx
+++ b/src/Modules/common/CodeEditor/CodeEditor.tsx
@@ -33,7 +33,7 @@ const CodeEditor = (props: ICodeEditorProps) => {
                     options={options}
                 />
                 <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-                    {lastSaved && <div className="last-saved">Last Saved at {dayjs(lastSaved).format('hh:MM ss')}</div>}
+                    {lastSaved && <div className="last-saved">Last Saved at {dayjs(lastSaved).format('hh:mm ss')}</div>}
                     <Button onClick={props.handleReset}>Reset</Button>
                     <Button
                         loading={props.saveLoading}

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -6,7 +6,7 @@ export type Json =
   | { [key: string]: Json | undefined }
   | Json[]
 
-export interface Database {
+export type Database = {
   public: {
     Tables: {
       assessment: {
@@ -16,6 +16,8 @@ export interface Database {
           code: string | null
           created_at: string | null
           exam_id: string | null
+          execution_memory: number | null
+          execution_time: number | null
           finished: string | null
           id: number
           joined: string | null
@@ -29,6 +31,8 @@ export interface Database {
           code?: string | null
           created_at?: string | null
           exam_id?: string | null
+          execution_memory?: number | null
+          execution_time?: number | null
           finished?: string | null
           id?: number
           joined?: string | null
@@ -42,6 +46,8 @@ export interface Database {
           code?: string | null
           created_at?: string | null
           exam_id?: string | null
+          execution_memory?: number | null
+          execution_time?: number | null
           finished?: string | null
           id?: number
           joined?: string | null
@@ -53,21 +59,24 @@ export interface Database {
           {
             foreignKeyName: "assessment_candidate_id_fkey"
             columns: ["candidate_id"]
+            isOneToOne: false
             referencedRelation: "candidate"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "assessment_challenge_id_fkey"
             columns: ["challenge_id"]
+            isOneToOne: false
             referencedRelation: "challenge"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "assessment_exam_id_fkey"
             columns: ["exam_id"]
+            isOneToOne: false
             referencedRelation: "exam"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       candidate: {
@@ -168,15 +177,17 @@ export interface Database {
           {
             foreignKeyName: "exam_challenge_challenge_id_fkey"
             columns: ["challenge_id"]
+            isOneToOne: false
             referencedRelation: "challenge"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "exam_challenge_exam_id_fkey"
             columns: ["exam_id"]
+            isOneToOne: false
             referencedRelation: "exam"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
       language_info: {
@@ -208,9 +219,10 @@ export interface Database {
           {
             foreignKeyName: "language_info_challenge_id_fkey"
             columns: ["challenge_id"]
+            isOneToOne: false
             referencedRelation: "challenge"
             referencedColumns: ["id"]
-          }
+          },
         ]
       }
     }
@@ -228,3 +240,85 @@ export interface Database {
     }
   }
 }
+
+type PublicSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never

--- a/supabase/functions/submit-exam/index.ts
+++ b/supabase/functions/submit-exam/index.ts
@@ -11,7 +11,7 @@ serve(async (req: Request) => {
     return new Response('ok', { headers: corsHeaders })
   }
 
-  const { id, language, code, result } = await req.json();
+  const { id, language, code, result, execution_memory, execution_time } = await req.json();
 
 
   const supabase = createClient(
@@ -40,6 +40,8 @@ serve(async (req: Request) => {
       code,
       status: Status.SUBMITTED,
       finished: new Date(),
+      execution_memory,
+      execution_time,
       result
     }).eq('id', id).select();
     if (error) {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added 'Execution Time' and 'Execution Memory' columns to the Dashboard module to display these metrics in the assessment table.
- Fixed the time format display issue in the CodeEditor component.
- Enhanced the Editor component by removing redundant code, adding execution metrics to the submission process, and improving state management.
- Updated the database schema types to include new fields for execution metrics.
- Modified the 'submit-exam' server function to handle new execution metrics fields.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dashboard.tsx</strong><dd><code>Add Execution Metrics Columns to Dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Modules/Dashboard/Dashboard.tsx
<li>Added new columns for 'Execution Time' and 'Execution Memory' in the <br>assessment table.<br> <li> Modified the 'Joined' column to include a default sort order.<br> <li> Minor formatting adjustment in the Row component.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/CodeGaze/pull/4/files#diff-b06fb7e825987eba352fe0ddaae515e2f404b98374bcdc8cd51d968f5fc2fab9">+23/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Editor.tsx</strong><dd><code>Enhance Editor's Submission and State Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Modules/common/CodeEditor/Editor.tsx
<li>Removed redundant useEffect that sets code and language from <br>assessment.<br> <li> Added execution time and memory to the submit function.<br> <li> Introduced a function to reset local state after submission.<br> <li> Changed autosave interval from 5000ms to 1000ms.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/CodeGaze/pull/4/files#diff-6e457df81111e63d563c84040853b0592fb78aedadcaeaaf4019321635351d58">+13/-11</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.ts</strong><dd><code>Update Schema Definitions with Execution Metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/schema.ts
<li>Updated 'Database' from interface to type.<br> <li> Added 'execution_memory' and 'execution_time' fields to assessment <br>table definitions.<br> <li> Added additional type definitions for handling database schema <br>interactions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/CodeGaze/pull/4/files#diff-2811f460bc361ad5494018c987e0713a599a5cb1ee2f70abb3aa9b831492c6a1">+98/-4</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update Submit Exam Function to Handle Execution Metrics</code>&nbsp; &nbsp; </dd></summary>
<hr>

supabase/functions/submit-exam/index.ts
<li>Updated function to receive 'execution_memory' and 'execution_time' <br>from the request.<br> <li> Added these new fields to the database update operation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/CodeGaze/pull/4/files#diff-bfdec6f659c6059591f46f2daaebc33bc5bc99ace79ad1ab025522335dad2a5f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CodeEditor.tsx</strong><dd><code>Fix Time Format in Code Editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Modules/common/CodeEditor/CodeEditor.tsx
<li>Corrected the time format in the 'Last Saved' display from 'hh:MM ss' <br>to 'hh:mm ss'.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/CodeGaze/pull/4/files#diff-9399e9c06cf86bd262d54dd342081955fb5d612118ea5df1244681ad432b00a8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

