### PR TITLE
fix: output string evaluator not working

### DIFF
--- a/src/Modules/CodeEvaluator/CodeEvaluator.ts
+++ b/src/Modules/CodeEvaluator/CodeEvaluator.ts
@@ -51,7 +51,7 @@ export class CodeEvaluator {
             if (output.status.id === CompilationStatus.ACCEPTED) {
                 const outputArray = output.stdout
                 .split(separator)
-                .map((output) => output.replace(/\n/g, ''))
+                .map((output) => output.replace(/(\n|['"])/g, ''))
                 .filter((output) => output);
                 evaluatorResult.result = this.evaluator.getResult(outputArray, testCases);
             }


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Improved the output string evaluator to handle quotes properly by extending the regex to also remove single (`'`) and double (`"`) quotes in addition to newlines.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CodeEvaluator.ts</strong><dd><code>Improve Output String Sanitization in CodeEvaluator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Modules/CodeEvaluator/CodeEvaluator.ts
<li>Enhanced the string sanitization in the output evaluation by also <br>removing single and double quotes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/CodeGaze/pull/5/files#diff-1f123d332b44920b901cef1633d1dd2c1094b0d042fbf9203bc3597d080f92ee">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

