### PR TITLE
fix: added difficulty in question page

### DIFF
--- a/src/Modules/CandidateAssessment/QuestionsPage.tsx
+++ b/src/Modules/CandidateAssessment/QuestionsPage.tsx
@@ -1,9 +1,9 @@
-import { Button, Divider, List, Skeleton, Typography } from 'antd';
+import { Button, Divider, List, Skeleton, Tag, Typography } from 'antd';
 import jwt_decode from 'jwt-decode';
 import { Content } from 'antd/es/layout/layout';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Challenge } from '../../types/Models';
+import { Challenge, difficultyMap } from '../../types/Models';
 import { ROUTES } from '../../constants/Route.constants';
 import './styles/Assessment.css';
 import { supabase } from '../API/supabase';
@@ -12,6 +12,7 @@ import { toast } from 'react-toastify';
 import Timer from './components/Timer';
 import { useDispatch, useSelector } from 'react-redux';
 import { IDispatch, IRootState } from '../../store';
+import CommonUtils from '../common/utils/Common.utils';
 const { Title } = Typography;
 
 const ChallengesListComponent = () => {
@@ -21,7 +22,6 @@ const ChallengesListComponent = () => {
     const [beginState, setBeginState] = useState<Record<string, '' | 'loading' | 'started'>>({});
     const [challenges, setchallenges] = useState<Challenge[]>([]);
 
-    const navigate = useNavigate();
     const dispatch = useDispatch<IDispatch>();
     const fetchExam = async () => {
         try {
@@ -108,7 +108,21 @@ const ChallengesListComponent = () => {
                     dataSource={challenges}
                     renderItem={(challenge) => (
                         <List.Item>
-                            <List.Item.Meta title={challenge.name} description={challenge.short_description} />
+                            <List.Item.Meta
+                                title={
+                                    <div>
+                                        {challenge.name}
+                                        <Tag
+                                            style={{ marginLeft: 10 }}
+                                            color={CommonUtils.getColor(challenge.difficulty)}
+                                        >
+                                            {difficultyMap[challenge.difficulty]}
+                                        </Tag>
+                                    </div>
+                                }
+                                description={challenge.short_description}
+                            />
+
                             {beginState[challenge.id] === 'started' ? (
                                 <Button disabled={true} type="primary">
                                     Started


### PR DESCRIPTION
## **User description**


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Enhanced the challenge list in `QuestionsPage.tsx` to display difficulty levels as colored tags next to the challenge names.
- Utilized `CommonUtils.getColor` for assigning colors based on difficulty, improving visual representation.
- Removed unused `navigate` import, cleaning up the code and dependencies.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>QuestionsPage.tsx</strong><dd><code>Enhance Challenge List with Difficulty Tags and Code Cleanup</code></dd></summary>
<hr>

src/Modules/CandidateAssessment/QuestionsPage.tsx
<li>Added <code>Tag</code> component from <code>antd</code> to display difficulty level next to <br>challenge names.<br> <li> Imported <code>difficultyMap</code> and <code>CommonUtils</code> to map difficulty levels to <br>colors.<br> <li> Enhanced challenge list items to include a tag showing the difficulty <br>level using a color code.<br> <li> Removed unused <code>navigate</code> import.<br>


</details>
    

  </td>
  <td><a href="https://github.com/visualbis/CodeGaze/pull/14/files#diff-2c89221d5f43466669b14624c7ebdce510516071b3143bd5cffbc2bd2363250b">+18/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

